### PR TITLE
Pass strict type checking

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -4,11 +4,11 @@
  * Use this if you are running Node on your server backend when you are working with Expo
  * https://expo.io
  */
-import assert from 'assert';
+import * as assert from 'assert';
 import { Agent } from 'http';
 import fetch, { Headers, Response as FetchResponse } from 'node-fetch';
-import promiseLimit from 'promise-limit';
-import zlib from 'zlib';
+import * as promiseLimit from 'promise-limit';
+import * as zlib from 'zlib';
 
 const BASE_URL = 'https://exp.host';
 const BASE_API_URL = `${BASE_URL}/--/api/v2`;
@@ -258,7 +258,7 @@ export default Expo;
 
 function _gzipAsync(data: Buffer): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    zlib.gzip(data, (error, result) => {
+    zlib.gzip(data, (error: Error, result: Buffer) => {
       if (error) {
         reject(error);
       } else {


### PR DESCRIPTION
The following errors occur when using strict type checking:

```
yarn run v1.7.0
$ tsc
node_modules/expo-server-sdk/src/ExpoClient.ts:7:8 - error TS1192: Module '"assert"' has no default export.

7 import assert from 'assert';
         ~~~~~~


node_modules/expo-server-sdk/src/ExpoClient.ts:10:8 - error TS1192: Module '"node_modules/promise-limit/index"' has no default export.

10 import promiseLimit from 'promise-limit';
          ~~~~~~~~~~~~


node_modules/expo-server-sdk/src/ExpoClient.ts:11:8 - error TS1192: Module '"zlib"' has no default export.

11 import zlib from 'zlib';
          ~~~~


node_modules/expo-server-sdk/src/ExpoClient.ts:261:22 - error TS7006: Parameter 'error' implicitly has an 'any' type.

261     zlib.gzip(data, (error, result) => {
                         ~~~~~


node_modules/expo-server-sdk/src/ExpoClient.ts:261:29 - error TS7006: Parameter 'result' implicitly has an 'any' type.

261     zlib.gzip(data, (error, result) => {
```