### PR TITLE
fix: don't throw when the SDK can't resolve its own package.json

### DIFF
--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -24,6 +24,23 @@ import {
 
 const require = createRequire(import.meta.url);
 
+// NOTE: This can be replaced with an import with the `{ type: "json" }`
+// attribute when we drop support for node versions below v20.10.0, when
+// import attributes were stabilized
+const sdkVersion = readSdkVersion();
+
+function readSdkVersion(): string {
+  // Bundlers (Metro's server export, esbuild, rolldown, …) inline this module into an output file
+  // elsewhere on disk, so the relative path either doesn't resolve at all or resolves to the
+  // consuming app's manifest. Neither is worth throwing over, or reporting as our version.
+  try {
+    const packageJson = require('../package.json');
+    return packageJson.name === 'expo-server-sdk' ? packageJson.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 export class Expo {
   static pushNotificationChunkSizeLimit = pushNotificationChunkLimit;
   static pushNotificationReceiptChunkSizeLimit = pushNotificationReceiptChunkLimit;
@@ -202,10 +219,6 @@ export class Expo {
     const json = JSON.stringify(options.body);
     assert(json != null, `JSON request body must not be null`);
 
-    // NOTE: This can be replaced with an import with the `{ type: "json" }`
-    // attribute when we drop support for node versions below v20.10.0, when
-    // import attributes were stabilized
-    const sdkVersion = require('../package.json').version;
     const requestHeaders = new Headers({
       Accept: 'application/json',
       'Accept-Encoding': 'gzip, deflate',

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { afterEach, beforeEach, describe, test } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 
 import ExpoClient, { type ExpoPushMessage } from '../ExpoClient.ts';
 import { getReceiptsApiUrl, sendApiUrl } from '../ExpoClientValues.ts';
+
+const require = createRequire(import.meta.url);
 
 const apiBaseUrl = 'https://exp.host';
 const accessToken = 'foobar';
@@ -28,6 +31,22 @@ describe('sending push notification messages', () => {
   test('resolves with the data from the server response', async () => {
     const mockPool = mockAgent.get(apiBaseUrl);
     mockPool.intercept({ path: sendApiUrl, method: 'POST' }).reply(200, { data: mockTickets });
+
+    assert.deepEqual(await client().sendPushNotificationsAsync([{ to: 'one' }]), mockTickets);
+  });
+
+  test('sends the SDK version in the User-Agent header', async () => {
+    const { version } = require('../../package.json');
+    const mockPool = mockAgent.get(apiBaseUrl);
+    mockPool
+      .intercept({
+        path: sendApiUrl,
+        method: 'POST',
+        headers: {
+          'User-Agent': `expo-server-sdk-node/${version}`,
+        },
+      })
+      .reply(200, { data: mockTickets });
 
     assert.deepEqual(await client().sendPushNotificationsAsync([{ to: 'one' }]), mockTickets);
   });


### PR DESCRIPTION
## Why

`requestAsync` reads the SDK version from `../package.json` on every request to build the `User-Agent` header. That relative path only points at the SDK's own manifest when the module is running from `node_modules/expo-server-sdk/build/`. Bundlers emit it elsewhere — `createRequire`'s local `require` binding isn't rewritten by them, so the lookup survives into the bundle and resolves against the output directory instead.

Two things go wrong there:

- **The manifest is missing → every push fails.** Expo Router's server export (expo/expo#46129) and Docker images that copy only the build output leave nothing one level up, so the require throws `Cannot find module '../package.json'` while assembling the headers — before any HTTP call is made, so nothing is sent and the error doesn't look like anything to do with a version string.
- **The manifest belongs to someone else → wrong telemetry.** When a `package.json` does sit there, it's the consuming app's, and its version is sent to the push service as the SDK version.

Reproduced both against `6.1.0` by placing the built files in `<root>/dist/`:

```
case A: no ../package.json at all
  THREW before sending -> Cannot find module '../package.json'
case B: ../package.json exists but is the consuming app's ({"name":"my-app","version":"9.9.9"})
  request sent, User-Agent: expo-server-sdk-node/9.9.9
```

## What

Read the version once at module load rather than per request, and fall back to `unknown` when the manifest can't be resolved or isn't this package's. A bundled deploy now degrades to a less precise `User-Agent` instead of failing every push:

```
case A: request sent, User-Agent: expo-server-sdk-node/unknown
case B: request sent, User-Agent: expo-server-sdk-node/unknown
```

The `{ type: "json" }` import the existing NOTE points to would fix this properly for bundlers (they can resolve and inline a static JSON import), so I've kept the NOTE. It isn't a drop-in today: `tsconfig.build.json` sets `rootDir: ./src`, and importing `../package.json` puts a file outside the root in the program, which changes the emitted layout and so the `exports` path. Felt out of scope for a bug fix — happy to follow up if you'd like it done that way instead.

## Test plan

- `node --run test` — added a case asserting the `User-Agent` carries the real version on the normal install path (fails if the header is wrong; verified by mutating it).
- `node --run tsc`, `node --run lint -- --max-warnings=0`.
- Built with `yarn prepack` and ran the two scenarios above by hand, before and after.

Fixes expo/expo#46129
