### PR TITLE
fix!: read the SDK version with a JSON import instead of require

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "yarn prepack",

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -12,9 +12,6 @@ import promiseRetry from 'promise-retry';
 import { fetch } from 'undici';
 import type { Dispatcher, Response, RequestInit } from 'undici';
 
-// Static so bundlers resolve the manifest at build time and inline the version; a runtime
-// require resolved against whatever directory the bundle ended up in instead.
-// https://github.com/expo/expo/issues/46129
 import packageJson from '../package.json' with { type: 'json' };
 import {
   defaultConcurrentRequestLimit,

--- a/src/ExpoClient.ts
+++ b/src/ExpoClient.ts
@@ -6,13 +6,16 @@
  * https://expo.dev
  */
 import assert from 'node:assert';
-import { createRequire } from 'node:module';
 import { gzipSync } from 'node:zlib';
 import promiseLimit from 'promise-limit';
 import promiseRetry from 'promise-retry';
 import { fetch } from 'undici';
 import type { Dispatcher, Response, RequestInit } from 'undici';
 
+// Static so bundlers resolve the manifest at build time and inline the version; a runtime
+// require resolved against whatever directory the bundle ended up in instead.
+// https://github.com/expo/expo/issues/46129
+import packageJson from '../package.json' with { type: 'json' };
 import {
   defaultConcurrentRequestLimit,
   getReceiptsApiUrl,
@@ -21,8 +24,6 @@ import {
   requestRetryMinTimeout,
   sendApiUrl,
 } from './ExpoClientValues.ts';
-
-const require = createRequire(import.meta.url);
 
 export class Expo {
   static pushNotificationChunkSizeLimit = pushNotificationChunkLimit;
@@ -202,14 +203,10 @@ export class Expo {
     const json = JSON.stringify(options.body);
     assert(json != null, `JSON request body must not be null`);
 
-    // NOTE: This can be replaced with an import with the `{ type: "json" }`
-    // attribute when we drop support for node versions below v20.10.0, when
-    // import attributes were stabilized
-    const sdkVersion = require('../package.json').version;
     const requestHeaders = new Headers({
       Accept: 'application/json',
       'Accept-Encoding': 'gzip, deflate',
-      'User-Agent': `expo-server-sdk-node/${sdkVersion}`,
+      'User-Agent': `expo-server-sdk-node/${packageJson.version}`,
       'Content-Type': 'application/json',
     });
     if (this.accessToken) {

--- a/src/__tests__/ExpoClient-test.ts
+++ b/src/__tests__/ExpoClient-test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, test } from 'node:test';
 import { gunzipSync } from 'node:zlib';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 
+import packageJson from '../../package.json' with { type: 'json' };
 import ExpoClient, { type ExpoPushMessage } from '../ExpoClient.ts';
 import { getReceiptsApiUrl, sendApiUrl } from '../ExpoClientValues.ts';
 
@@ -28,6 +29,21 @@ describe('sending push notification messages', () => {
   test('resolves with the data from the server response', async () => {
     const mockPool = mockAgent.get(apiBaseUrl);
     mockPool.intercept({ path: sendApiUrl, method: 'POST' }).reply(200, { data: mockTickets });
+
+    assert.deepEqual(await client().sendPushNotificationsAsync([{ to: 'one' }]), mockTickets);
+  });
+
+  test('sends the SDK version in the User-Agent header', async () => {
+    const mockPool = mockAgent.get(apiBaseUrl);
+    mockPool
+      .intercept({
+        path: sendApiUrl,
+        method: 'POST',
+        headers: {
+          'User-Agent': `expo-server-sdk-node/${packageJson.version}`,
+        },
+      })
+      .reply(200, { data: mockTickets });
 
     assert.deepEqual(await client().sendPushNotificationsAsync([{ to: 'one' }]), mockTickets);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "@tsconfig/bases/strictest",
-    "@tsconfig/bases/node20", // The minimum supported major node version
+    "@tsconfig/bases/node22", // The minimum supported major node version
     "@tsconfig/bases/node-ts"
   ],
   "compilerOptions": {


### PR DESCRIPTION
Replaces #276, which patched around the `require` instead of removing it. Per the discussion there (@vonovak: "let's follow the comment and bump min supported node"), this does the version lookup the NOTE in the code asked for.

## Why

`requestAsync` built its `User-Agent` from `require('../package.json')` on every request. That relative path only points at the SDK's own manifest while the module runs from `node_modules/expo-server-sdk/build/`. Bundlers emit it elsewhere and don't rewrite `createRequire`'s local `require` binding, so the lookup survives into the bundle and resolves against the output directory instead.

- **No manifest one level up: every push fails.** Expo Router's server export (expo/expo#46129) and Docker images that copy only the build output leave nothing there, so the require throws `Cannot find module '../package.json'` while assembling the headers. That is before any HTTP call, so nothing is sent and the error doesn't look like it has anything to do with a version string.
- **A manifest that belongs to someone else: wrong telemetry.** When a `package.json` does sit there it's the consuming app's, and its version goes to the push service as the SDK version.

## What

`import packageJson from '../package.json' with { type: 'json' }`. Bundlers resolve a static JSON import at build time and inline it, so both failures go away, and the version is read once at module load rather than per request.

That needs `engines.node` raised. Import attributes and JSON modules are stable as of **v22.12.0** (nodejs/node#55333); on v22.11.0 the import works but prints `ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time` into every consumer's logs on first import, which I checked on both binaries:

```
node v22.11.0  request sent, User-Agent: expo-server-sdk-node/6.1.0
               (node:4786) ExperimentalWarning: Importing JSON modules is an experimental feature
node v22.12.0  request sent, User-Agent: expo-server-sdk-node/6.1.0
```

So the floor is `>=22.12.0` rather than the `>=22.11.0` suggested in the review, and `tsconfig.json` moves to the `node22` base. Happy to drop it back to 22.11.0 if you'd rather have the warning.

One honest tradeoff: if the manifest genuinely can't be resolved, the failure now happens at import rather than on the first push. That case is a broken deploy either way (`build/*.js` copied out of the package by hand, with no bundler involved); the bundler paths that people actually hit are fixed because the JSON gets inlined.

`rootDir: ./src` turned out not to be a problem, contrary to what I wrote in #276: TypeScript 5.9 pulls `package.json` into the program for typing but does not emit it, so `build/` and the published file list are unchanged (`yarn npm publish --dry-run` lists the same 5 entries).

## Test plan

- `node --run test` (45 pass), including a new case asserting the `User-Agent` carries the real version on the normal install path. Verified it fails if the header is wrong.
- `node --run tsc`, `node --run lint -- --max-warnings=0`, `yarn npm publish --dry-run`.
- Packed a tarball before and after, installed each into a scratch app, and drove one `sendPushNotificationsAsync` against a local server (via `EXPO_BASE_URL`) to read the `User-Agent` off the wire. Bundled with esbuild into two output locations to cover both failure modes:

  | scenario | before | after |
  | --- | --- | --- |
  | normal install, no bundler | `expo-server-sdk-node/6.1.0` | `expo-server-sdk-node/6.1.0` |
  | bundle at `dist/server/index.mjs`, nothing at `../package.json` | throws `Cannot find module '../package.json'`, nothing sent | `expo-server-sdk-node/6.1.0` |
  | bundle at `dist/index.mjs`, `../package.json` is the app's own | sends the app's version, `expo-server-sdk-node/1.0.0` | `expo-server-sdk-node/6.1.0` |

- For the Metro path in expo/expo#46129 I checked that the parser Expo 57 ships (hermes-parser 0.36.1) accepts the import attribute syntax, so this is parseable there. I did not run a full server export.

Fixes expo/expo#46129
